### PR TITLE
Python 2.7 syntax support

### DIFF
--- a/activecampaign/Account.py
+++ b/activecampaign/Account.py
@@ -11,7 +11,7 @@ class Account(ActiveCampaign):
     def __init__(self, url, api_key):
         self.url = url
         self.api_key = api_key
-        super().__init__(url, api_key)
+        super(Account, self).__init__(url, api_key)
 
     def add(self, params, post_data={}):
         rq_url = fmt_noparams(

--- a/activecampaign/Account.py
+++ b/activecampaign/Account.py
@@ -11,7 +11,7 @@ class Account(ActiveCampaign):
     def __init__(self, url, api_key):
         self.url = url
         self.api_key = api_key
-        super(Account, self).__init__(url, api_key)
+        super().__init__(url, api_key)
 
     def add(self, params, post_data={}):
         rq_url = fmt_noparams(

--- a/activecampaign/ActiveCampaign.py
+++ b/activecampaign/ActiveCampaign.py
@@ -19,7 +19,7 @@ class ActiveCampaign(Connector):
         self.api_key = api_key
         self.URL = url
         self.APIKEY = api_key
-        super().__init__(url, api_key, api_user, api_pass)
+        super(ActiveCampaign, self).__init__(url, api_key, api_user, api_pass)
 
     def api(self, path, post_data={}):
         # IE: "contact/view"

--- a/activecampaign/ActiveCampaign.py
+++ b/activecampaign/ActiveCampaign.py
@@ -19,7 +19,7 @@ class ActiveCampaign(Connector):
         self.api_key = api_key
         self.URL = url
         self.APIKEY = api_key
-        super(ActiveCampaign, self).__init__(url, api_key, api_user, api_pass)
+        super().__init__(url, api_key, api_user, api_pass)
 
     def api(self, path, post_data={}):
         # IE: "contact/view"

--- a/activecampaign/Campaign.py
+++ b/activecampaign/Campaign.py
@@ -11,7 +11,7 @@ class Campaign(ActiveCampaign):
     def __init__(self, url, api_key):
         self.url = url
         self.api_key = api_key
-        super().__init__(url, api_key)
+        super(Campaign, self).__init__(url, api_key)
 
     def create(self, params, post_data):
         rq_url = fmt_noparams(

--- a/activecampaign/Campaign.py
+++ b/activecampaign/Campaign.py
@@ -11,7 +11,7 @@ class Campaign(ActiveCampaign):
     def __init__(self, url, api_key):
         self.url = url
         self.api_key = api_key
-        super(Campaign, self).__init__(url, api_key)
+        super().__init__(url, api_key)
 
     def create(self, params, post_data):
         rq_url = fmt_noparams(

--- a/activecampaign/Connector.py
+++ b/activecampaign/Connector.py
@@ -1,7 +1,7 @@
 import requests as rq
 
 
-class Connector():
+class Connector(object):
 
     def __init__(self, url, api_key, api_user='', api_pass=''):
         self.output = 'json'

--- a/activecampaign/Contact.py
+++ b/activecampaign/Contact.py
@@ -11,7 +11,7 @@ class Contact(ActiveCampaign):
     def __init__(self, url, api_key):
         self.url = url
         self.api_key = api_key
-        super().__init__(url, api_key)
+        super(Contact, self).__init__(url, api_key)
 
     def add(self, params, post_data={}):
         if params:

--- a/activecampaign/Contact.py
+++ b/activecampaign/Contact.py
@@ -11,7 +11,7 @@ class Contact(ActiveCampaign):
     def __init__(self, url, api_key):
         self.url = url
         self.api_key = api_key
-        super(Contact, self).__init__(url, api_key)
+        super().__init__(url, api_key)
 
     def add(self, params, post_data={}):
         if params:

--- a/activecampaign/Design.py
+++ b/activecampaign/Design.py
@@ -11,7 +11,7 @@ class Design(ActiveCampaign):
     def __init__(self, url, api_key):
         self.url = url
         self.api_key = api_key
-        super().__init__(url, api_key)
+        super(Design, self).__init__(url, api_key)
 
     def edit(self, params, post_data):
         rq_url = fmt_noparams(

--- a/activecampaign/Design.py
+++ b/activecampaign/Design.py
@@ -11,7 +11,7 @@ class Design(ActiveCampaign):
     def __init__(self, url, api_key):
         self.url = url
         self.api_key = api_key
-        super(Design, self).__init__(url, api_key)
+        super().__init__(url, api_key)
 
     def edit(self, params, post_data):
         rq_url = fmt_noparams(

--- a/activecampaign/Form.py
+++ b/activecampaign/Form.py
@@ -11,7 +11,7 @@ class Form(ActiveCampaign):
     def __init__(self, url, api_key):
         self.url = url
         self.api_key = api_key
-        super().__init__(url, api_key)
+        super(Form, self).__init__(url, api_key)
 
     def getforms(self, params, post_data={}):
         rq_url = fmt_noparams(

--- a/activecampaign/Form.py
+++ b/activecampaign/Form.py
@@ -11,7 +11,7 @@ class Form(ActiveCampaign):
     def __init__(self, url, api_key):
         self.url = url
         self.api_key = api_key
-        super(Form, self).__init__(url, api_key)
+        super().__init__(url, api_key)
 
     def getforms(self, params, post_data={}):
         rq_url = fmt_noparams(

--- a/activecampaign/Group.py
+++ b/activecampaign/Group.py
@@ -11,7 +11,7 @@ class Group(ActiveCampaign):
     def __init__(self, url, api_key):
         self.url = url
         self.api_key = api_key
-        super().__init__(url, api_key)
+        super(Group, self).__init__(url, api_key)
 
     def add(self, params, post_data):
         rq_url = fmt_noparams(

--- a/activecampaign/Group.py
+++ b/activecampaign/Group.py
@@ -11,7 +11,7 @@ class Group(ActiveCampaign):
     def __init__(self, url, api_key):
         self.url = url
         self.api_key = api_key
-        super(Group, self).__init__(url, api_key)
+        super().__init__(url, api_key)
 
     def add(self, params, post_data):
         rq_url = fmt_noparams(

--- a/activecampaign/List.py
+++ b/activecampaign/List.py
@@ -11,7 +11,7 @@ class List(ActiveCampaign):
     def __init__(self, url, api_key):
         self.url = url
         self.api_key = api_key
-        super().__init__(url, api_key)
+        super(List, self).__init__(url, api_key)
 
     def add(self, params, post_data):
         rq_url = fmt_noparams(

--- a/activecampaign/List.py
+++ b/activecampaign/List.py
@@ -11,7 +11,7 @@ class List(ActiveCampaign):
     def __init__(self, url, api_key):
         self.url = url
         self.api_key = api_key
-        super(List, self).__init__(url, api_key)
+        super().__init__(url, api_key)
 
     def add(self, params, post_data):
         rq_url = fmt_noparams(

--- a/activecampaign/Message.py
+++ b/activecampaign/Message.py
@@ -11,7 +11,7 @@ class Message(ActiveCampaign):
     def __init__(self, url, api_key):
         self.url = url
         self.api_key = api_key
-        super().__init__(url, api_key)
+        super(Message, self).__init__(url, api_key)
 
     def add(self, params, post_data):
         rq_url = fmt_noparams(

--- a/activecampaign/Message.py
+++ b/activecampaign/Message.py
@@ -11,7 +11,7 @@ class Message(ActiveCampaign):
     def __init__(self, url, api_key):
         self.url = url
         self.api_key = api_key
-        super(Message, self).__init__(url, api_key)
+        super().__init__(url, api_key)
 
     def add(self, params, post_data):
         rq_url = fmt_noparams(

--- a/activecampaign/Organization.py
+++ b/activecampaign/Organization.py
@@ -11,7 +11,7 @@ class Organization(ActiveCampaign):
     def __init__(self, url, api_key):
         self.url = url
         self.api_key = api_key
-        super().__init__(url, api_key)
+        super(Organization, self).__init__(url, api_key)
 
     def list_(self, params):
         rq_url = fmt_params(self.url, 'organization_list',

--- a/activecampaign/Organization.py
+++ b/activecampaign/Organization.py
@@ -11,7 +11,7 @@ class Organization(ActiveCampaign):
     def __init__(self, url, api_key):
         self.url = url
         self.api_key = api_key
-        super(Organization, self).__init__(url, api_key)
+        super().__init__(url, api_key)
 
     def list_(self, params):
         rq_url = fmt_params(self.url, 'organization_list',

--- a/activecampaign/User.py
+++ b/activecampaign/User.py
@@ -11,7 +11,7 @@ class User(ActiveCampaign):
     def __init__(self, url, api_key):
         self.url = url
         self.api_key = api_key
-        super().__init__(url, api_key)
+        super(User, self).__init__(url, api_key)
 
     def add(self, params, post_data):
         rq_url = fmt_noparams(

--- a/activecampaign/User.py
+++ b/activecampaign/User.py
@@ -11,7 +11,7 @@ class User(ActiveCampaign):
     def __init__(self, url, api_key):
         self.url = url
         self.api_key = api_key
-        super(User, self).__init__(url, api_key)
+        super().__init__(url, api_key)
 
     def add(self, params, post_data):
         rq_url = fmt_noparams(

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ test_requirements = [
 
 setup(
     name='active-campaign-python',
-    version='0.9.0',
+    version='0.9.1',
     description="Python ActiveCampaign API client",
     long_description=readme,
     author="Dennis Durling",

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ test_requirements = [
 
 setup(
     name='active-campaign-python',
-    version='0.9.1',
+    version='0.9.0',
     description="Python ActiveCampaign API client",
     long_description=readme,
     author="Dennis Durling",


### PR DESCRIPTION
Library is not working under Python 2.7, as the super calls are using the Python3 syntax.
This PR fixes the issue, as the old syntax of super calls works with both python 2.7 and 3.x